### PR TITLE
fix: prevent DateInput overflow on mobile

### DIFF
--- a/src/lib/components/DateInput.svelte
+++ b/src/lib/components/DateInput.svelte
@@ -25,7 +25,10 @@
 
 <style>
   input {
-    display: inline;
+    display: block;
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
     color: var(--c-body);
     padding-inline: var(--textFrameX);
     padding-block: var(--textFrameY);


### PR DESCRIPTION
Fixes an issue where the date input overflowed its parent on mobile.

Before:
<img width="1134" height="2048" alt="grafik" src="https://github.com/user-attachments/assets/840e44fe-552b-4b39-b422-b3b79248349c" />

After fix:
<img width="1119" height="2048" alt="grafik" src="https://github.com/user-attachments/assets/1eed7ab6-8943-40af-bcab-4bd85a8719da" />
